### PR TITLE
Placeholder support for sqlite3-execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Execute SQL `query` for `db` database.
 First argument `db` must be sqlite3 instance. If you use placeholders in `query`,
 then you must pass `bounds` too.
 
-#### `(sqlite3-execute db query &optional callback)`
+#### `(sqlite3-execute db query &optional callback bounds)`
 
 Interface for executing `SELECT` query. If you pass `callback` argument,
 `callback` is called with `SELECT` results. `callback` takes 2 arguments,

--- a/sqlite3-core.c
+++ b/sqlite3-core.c
@@ -255,20 +255,30 @@ Fsqlite3_execute(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data
 	sqlite3 *sdb = env->get_user_ptr(env, args[0]);
 	ptrdiff_t size;
 	char *query = retrieve_string(env, args[1], &size);
+	emacs_value Qnil = env->intern(env, "nil");
+	emacs_value retval = Qnil;
+	const char *errmsg = NULL;
 
 	sqlite3_stmt *stmt = NULL;
 	int ret = sqlite3_prepare_v2(sdb, query, size, &stmt, NULL);
+	if (nargs > 3) {
+		const char *err = bind_values(env, sdb, stmt, args[3]);
+		if (err != NULL) {
+			errmsg = err;
+			goto exit;
+		}
+	}
+
 	if (ret != SQLITE_OK) {
 		if (stmt) {
 			sqlite3_finalize(stmt);
 		}
 
-		free(query);
-		return env->intern(env, "nil");
+		goto exit;
 	}
 
 	emacs_value Qcons = env->intern(env, "cons");
-	emacs_value fields = env->intern(env, "nil");
+	emacs_value fields = Qnil;
 	int count = sqlite3_column_count(stmt);
 	for (int i = 0; i < count; ++i) {
 		const char *name = sqlite3_column_name(stmt, i);
@@ -291,7 +301,8 @@ Fsqlite3_execute(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data
 		result->stmt = stmt;
 		result->fields = fields;
 		result->eof = false;
-		return env->make_user_ptr(env, el_sqlite3_resultset_free, result);
+		retval = env->make_user_ptr(env, el_sqlite3_resultset_free, result);
+		goto exit;
 	}
 
 	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
@@ -302,11 +313,16 @@ Fsqlite3_execute(emacs_env *env, ptrdiff_t nargs, emacs_value args[], void *data
 	}
 
 	sqlite3_finalize(stmt);
-	if (ret != SQLITE_OK && ret != SQLITE_DONE) {
-		return env->intern(env, "nil");
+
+ exit:
+	free(query);
+
+	if (errmsg != NULL) {
+		emacs_value errstr = env->make_string(env, errmsg, strlen(errmsg));
+		env->non_local_exit_signal(env, env->intern(env, "error"), errstr);
 	}
 
-	return env->intern(env, "nil");
+	return retval;
 }
 
 static emacs_value
@@ -410,7 +426,7 @@ emacs_module_init(struct emacs_runtime *ert)
 
 	DEFUN("sqlite3-core-new", Fsqlite3_new, 1, 1, NULL, NULL);
 	DEFUN("sqlite3-core-execute-batch", Fsqlite3_execute_batch, 2, 3, NULL, NULL);
-	DEFUN("sqlite3-core-execute", Fsqlite3_execute, 3, 3, NULL, NULL);
+	DEFUN("sqlite3-core-execute", Fsqlite3_execute, 3, 4, NULL, NULL);
 	DEFUN("sqlite3-transaction", Fsqlite3_transaction, 1, 1, NULL, NULL);
 	DEFUN("sqlite3-commit", Fsqlite3_commit, 1, 1, NULL, NULL);
 	DEFUN("sqlite3-rollback", Fsqlite3_rollback, 1, 1, NULL, NULL);

--- a/sqlite3.el
+++ b/sqlite3.el
@@ -43,14 +43,19 @@ into memory."
       (setq bounds (vconcat bounds)))
     (sqlite3-core-execute-batch sqlite query bounds)))
 
-(defun sqlite3-execute (sqlite query &optional callback)
+(defun sqlite3-execute (sqlite query &optional callback bounds)
   "Execute SQL `query' which has `SELECT' command. If `callback' argument is
 specified, `callback' function is called with database row. `callback' takes
 two arguments, first argument is row element of list, second argument is
 field names of list."
   (cl-assert (not (null sqlite)))
   (cl-assert (stringp query))
-  (sqlite3-core-execute sqlite query callback))
+  (if (null bounds)
+      (sqlite3-core-execute sqlite query callback)
+    (unless (vectorp bounds)
+      (cl-assert (listp bounds))
+      (setq bounds (vconcat bounds)))
+    (sqlite3-core-execute sqlite query callback bounds)))
 
 (provide 'sqlite3)
 


### PR DESCRIPTION
Hi,

1. I want to use `sqlite3-execute` function with placeholder, so I modified the function to accept optional argument `bounds` like `sqlite3-execute-batch` function.
2. In `sqlite3-execute`, allocated memory for `query` is not freed in almost case.

Please see the commit.